### PR TITLE
Fix WormholeScan -> Wormholescan

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -36,7 +36,7 @@
   * [Tilt](reference/dev-env/tilt.md)
   * [Tooling](reference/dev-env/tooling.md)
 * [API Docs](reference/api-docs/README.md)
-  * [WormholeScan API](reference/api-docs/swagger.md)
+  * [Wormholescan API](reference/api-docs/swagger.md)
 * [SDK Docs](reference/sdk-docs/README.md)
   * [Connect SDK](reference/sdk-docs/connect-sdk.md)
 * [CLI Docs](reference/cli-docs/README.md)


### PR DESCRIPTION
<img width="1710" alt="Screenshot 2023-10-28 at 12 33 32 PM" src="https://github.com/wormhole-foundation/docs.wormhole.com/assets/689351/df52deb1-49d8-410d-88f2-a520c69302d4">


"WormholeScan" should be "Wormholescan"