### PR TITLE
fix: wrong npm package name

### DIFF
--- a/docs/reference/sdk-docs/connect-sdk.md
+++ b/docs/reference/sdk-docs/connect-sdk.md
@@ -37,7 +37,7 @@ const wh = new Wormhole(network, [EvmContext, SolanaContext]);
 // look up configuration parameters or  even parse addresses 
 const srcChain = wh.getChain('Ethereum');
 
-srcChain.parseAddress("0xdeadbeef...") // => NativeAddress<'Evm'>
+Wormhole.parseAddress('Ethereum', "0xdeadbeef...") // => NativeAddress<'Evm'>
 await srcChain.getTokenBridge() // => TokenBridge<'Evm'>
 srcChain.getRpcClient() // => RpcClient<'Evm'>
 ```

--- a/docs/reference/sdk-docs/connect-sdk.md
+++ b/docs/reference/sdk-docs/connect-sdk.md
@@ -37,7 +37,7 @@ const wh = new Wormhole(network, [EvmContext, SolanaContext]);
 // look up configuration parameters or  even parse addresses 
 const srcChain = wh.getChain('Ethereum');
 
-Wormhole.parseAddress('Ethereum', "0xdeadbeef...") // => NativeAddress<'Evm'>
+srcChain.parseAddress("0xdeadbeef...") // => NativeAddress<'Evm'>
 await srcChain.getTokenBridge() // => TokenBridge<'Evm'>
 srcChain.getRpcClient() // => RpcClient<'Evm'>
 ```

--- a/docs/tutorials/quick-start/cctp/sdk.md
+++ b/docs/tutorials/quick-start/cctp/sdk.md
@@ -8,7 +8,7 @@ First install the required packages to use CCTP on EVM compatible platforms (or 
 npm install \
     @wormhole-foundation/connect-sdk \
     @wormhole-foundation/connect-sdk-evm \
-    @wormhole-foundation-connect-sdk-evm-cctp
+    @wormhole-foundation/connect-sdk-evm-cctp
 ```
 
 


### PR DESCRIPTION
- npm install command fails with invalid npm package name 

Also it looks like the doc is for sdk version 3.0 when 0.2.6 is still the version with 'latest' tag on npm? Was confusing for a bit