### PR TITLE
chore(docs): Update Twitter Link

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -71,5 +71,5 @@
 - [Guardian Dashboard](https://wormhole-foundation.github.io/wormhole-dashboard/)
 - [Portal Bridge Docs](https://www.portalbridge.com/docs/)
 - [Discord](https://discord.gg/hJfuptmg6b)
-- [Twitter](https://twitter.com/wormholecrypto)
+- [Twitter](https://twitter.com/wormhole)
 - [Github](https://github.com/wormhole-foundation)


### PR DESCRIPTION
The link to the Twitter account in the documentation was broken/outdated. This PR updates it to point to the official handle (https://twitter.com/wormhole). This will ensure users have access to the correct information about following the project on Twitter.