### PR TITLE
Fixed some links within the docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ Wormhole is a generic **message passing protocol** that enables communication be
 The above is an _oversimplified_ illustration of the protocol, details about the architecture and components are available [here](./reference/components/README.md)
 {% endhint %}
 
-This simple **message passing protocol** enables developers and users of [cross chain applications](./reference/glossary.md#xdapps) built by developers to leverage the advantages of multiple ecosystems.
+This simple **message passing protocol** enables developers and users of [cross chain applications](./reference/glossary.md#xdapp) built by developers to leverage the advantages of multiple ecosystems.
 
 ### What Isn't Wormhole?
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,7 +32,7 @@ Tutorials are available to get started quickly and explain the concepts involved
 
 <table data-card-size="large" data-view="cards" data-full-width="false"><thead><tr><th></th><th></th><th data-hidden data-card-target data-type="content-ref"></th><th data-hidden data-card-cover data-type="files"></th></tr></thead><tbody><tr><td><strong>Quick Start</strong> - Off Chain</td><td>Integrate Wormhole Connect to a new or existing web UI</td><td><a href="./tutorials/quick-start/wh-connect.md">wh-connect.md</a></td><td><a href=".gitbook/assets/wh-connect-default.png">wh-connect-default.png</a></td></tr><tr><td><strong>Quick Start</strong> - On Chain</td><td>Send your first cross chain message</td><td><a href="./tutorials/quick-start/cross-chain-dev/README.md">cross-chain-dev</a></td><td><a href=".gitbook/assets/wh-line-art.png">wh-line-art.png</a></td></tr></tbody></table>
 
-More tutorials are available [here](./tutorials/quick-start/README.md).
+More tutorials are available [here](./tutorials/quick-start).
 
 ### Explore
 

--- a/docs/reference/components/core-contracts.md
+++ b/docs/reference/components/core-contracts.md
@@ -87,7 +87,7 @@ Because the VAA creation is separate from relaying, there is _no additional cost
 Before a token transfer can be made, the token being transfered must exist as a wrapped asset on the target chain. This is done by [Attesting](./vaa.md) the token details on the target chain. 
 {% endhint %}
 
-The Token Bridge contract allows token transfers between blockchains through a lock and mint mechanism, using the [Core Contract](#core-contract) with a [specific payload](./vaa.md#transfer) to pass information about the transfer.
+The Token Bridge contract allows token transfers between blockchains through a lock and mint mechanism, using the [Core Contract](#core-contract) with a [specific payload](./vaa.md#token-transfer) to pass information about the transfer.
 
 The Token Bridge also supports sending tokens with some additional data in the form of arbitrary byte payload attached to the token transfer. This type of transfer is referred to as a [Contract Controlled Transfer](./vaa.md#token--message).
 

--- a/docs/reference/components/core-contracts.md
+++ b/docs/reference/components/core-contracts.md
@@ -84,7 +84,7 @@ Because the VAA creation is separate from relaying, there is _no additional cost
 ## Token Bridge
 
 {% hint style="info" %}
-Before a token transfer can be made, the token being transfered must exist as a wrapped asset on the target chain. This is done by [Attesting](./vaa.md) the token details on the target chain. 
+Before a token transfer can be made, the token being transfered must exist as a wrapped asset on the target chain. This is done by [Attesting](./vaa.md#attestation) the token details on the target chain. 
 {% endhint %}
 
 The Token Bridge contract allows token transfers between blockchains through a lock and mint mechanism, using the [Core Contract](#core-contract) with a [specific payload](./vaa.md#token-transfer) to pass information about the transfer.


### PR DESCRIPTION
1. **Cross chain application** link: The original link was pointing to the glossary but not exactly at the xDapps where we really want it to point, maybe just a typo error, or the reference got changed later...Anyway got it fixed.
2. **More Tutorials** link: The original link was pointing to the `quick-start's README` section within this repository itself which ain't built yet and doesn't provide anything to the user (although the side tab does, but that's a click away). Thus, pointed to the `quick-start` directory which at least makes them view additional tutorials.

Right now, I am exploring Wormhole as part of the educational series which is in collaboration with Encode club. One of the features I like about this documentation is that `Docs AI` present in the bottom-right corner, truly worth it. Kudos to the devs...

Thanks!