### PR TITLE
Referenced `gasdrop-off` to the exact destination

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ Wormhole is a generic **message passing protocol** that enables communication be
 The above is an _oversimplified_ illustration of the protocol, details about the architecture and components are available [here](./reference/components/README.md)
 {% endhint %}
 
-This simple **message passing protocol** enables developers and users of [cross chain applications](./reference/glossary.md#xdapps) built by developers to leverage the advantages of multiple ecosystems.
+This simple **message passing protocol** enables developers and users of [cross chain applications](./reference/glossary.md#xdapp) built by developers to leverage the advantages of multiple ecosystems.
 
 ### What Isn't Wormhole?
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,7 +32,7 @@ Tutorials are available to get started quickly and explain the concepts involved
 
 <table data-card-size="large" data-view="cards" data-full-width="false"><thead><tr><th></th><th></th><th data-hidden data-card-target data-type="content-ref"></th><th data-hidden data-card-cover data-type="files"></th></tr></thead><tbody><tr><td><strong>Quick Start</strong> - Off Chain</td><td>Integrate Wormhole Connect to a new or existing web UI</td><td><a href="./tutorials/quick-start/wh-connect.md">wh-connect.md</a></td><td><a href=".gitbook/assets/wh-connect-default.png">wh-connect-default.png</a></td></tr><tr><td><strong>Quick Start</strong> - On Chain</td><td>Send your first cross chain message</td><td><a href="./tutorials/quick-start/cross-chain-dev/README.md">cross-chain-dev</a></td><td><a href=".gitbook/assets/wh-line-art.png">wh-line-art.png</a></td></tr></tbody></table>
 
-More tutorials are available [here](./tutorials/quick-start/README.md).
+More tutorials are available [here](./tutorials/quick-start).
 
 ### Explore
 

--- a/docs/connect/features.md
+++ b/docs/connect/features.md
@@ -29,7 +29,7 @@
 
 ## Feature Explanation
 
-**Token Bridge**
+#### **Token Bridge**
 
 This is the transfer method that Wormhole is best known for. It locks assets on the source chain, and mints wormhole-wrapped "IOU" tokens on the destination chain. To transfer the assets back, the wormhole-wrapped tokens are burned, which unlocks the tokens on their original chain.
 
@@ -37,7 +37,7 @@ This route appears if
 - both the origin and destination chains support Token Bridge 
 - and if no non-Token Bridge routes are available for the selected token
 
-**Token Bridge Relayer**
+#### **Token Bridge Relayer**
 
 {% hint style="info" %}
 On the [routes](../connect/routes.md) page, this is referred to the "automatic route" in the Token Bridge section.
@@ -51,7 +51,7 @@ This route appears if
 - if no non-Token Bridge routes are available for the selected token
 - the selected token on the origin chain is supported by the relayer
 
-**Circle CCTP**
+#### **Circle CCTP**
 
 [Circle](https://www.circle.com/en/), issuer of USDC, provides a native way by which native USDC can be transferred between [CCTP enabled](https://www.circle.com/en/cross-chain-transfer-protocol) chains.
 
@@ -59,7 +59,7 @@ This route appears if
 - both the origin and destination chains support Circle CCTP
 - the selected token is native Circle-issued USDC
 
-**ETH Bridge**
+#### **ETH Bridge**
 
 [Powered by Uniswap liquidity pools](https://github.com/wormhole-foundation/example-uniswap-liquidity-layer), this route can transfer native ETH or wstETH between certain EVMs without going through the native bridges.
 
@@ -67,7 +67,7 @@ This route appears if
 - both the origin and destination chains support the ETH Bridge
 - the selected token is native ETH or wstETH, or canonical wETH
 
-**Gas Dropoff**
+#### **Gas Dropoff**
 
 Relayers are able to drop off some gas tokens on the destination chain by swapping some of the assets transferred to the native gas token. Useful if the user wishes to transfer assets to a chain where they don't already have gas. This way, they don't need to onboard into the ecosystem from a CEX.
 

--- a/docs/connect/overview.md
+++ b/docs/connect/overview.md
@@ -19,7 +19,7 @@ This is just an overview of what features are available. For details about each,
 - extensive ways to style the UI (also try the [codeless styler interface](https://connect-in-style.wormhole.com/)!)
 - ways to [configure](./configuration.md) what feature set to offer
 - ability to configure any token to bridge via Wormhole
-- [drop off some gas](./features.md) at the destination
+- [drop off some gas](./features.md#gas-dropoff) at the destination
 
 ## Demo
 

--- a/docs/reference/components/core-contracts.md
+++ b/docs/reference/components/core-contracts.md
@@ -87,7 +87,7 @@ Because the VAA creation is separate from relaying, there is _no additional cost
 Before a token transfer can be made, the token being transfered must exist as a wrapped asset on the target chain. This is done by [Attesting](./vaa.md) the token details on the target chain. 
 {% endhint %}
 
-The Token Bridge contract allows token transfers between blockchains through a lock and mint mechanism, using the [Core Contract](#core-contract) with a [specific payload](./vaa.md#transfer) to pass information about the transfer.
+The Token Bridge contract allows token transfers between blockchains through a lock and mint mechanism, using the [Core Contract](#core-contract) with a [specific payload](./vaa.md#token-transfer) to pass information about the transfer.
 
 The Token Bridge also supports sending tokens with some additional data in the form of arbitrary byte payload attached to the token transfer. This type of transfer is referred to as a [Contract Controlled Transfer](./vaa.md#token--message).
 

--- a/docs/reference/components/core-contracts.md
+++ b/docs/reference/components/core-contracts.md
@@ -84,7 +84,7 @@ Because the VAA creation is separate from relaying, there is _no additional cost
 ## Token Bridge
 
 {% hint style="info" %}
-Before a token transfer can be made, the token being transfered must exist as a wrapped asset on the target chain. This is done by [Attesting](./vaa.md) the token details on the target chain. 
+Before a token transfer can be made, the token being transfered must exist as a wrapped asset on the target chain. This is done by [Attesting](./vaa.md#attestation) the token details on the target chain. 
 {% endhint %}
 
 The Token Bridge contract allows token transfers between blockchains through a lock and mint mechanism, using the [Core Contract](#core-contract) with a [specific payload](./vaa.md#token-transfer) to pass information about the transfer.


### PR DESCRIPTION
I noticed a `drop the gas off` link within the [Overview](https://docs.wormhole.com/wormhole/wormhole-connect/overview#features) section of `Connect` that was pointing to the correct page but not exactly at the destination.

Fixed it by converting those bold headings (that can't be pointed at) to the ones whose link can be grabbed by using markdown hashes (####) in the referred [page](https://github.com/wormhole-foundation/docs.wormhole.com/blob/main/docs/connect/features.md)

Thanks!